### PR TITLE
Setup GitHub Actions to Build and Push Docker Image Automatically

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -1,9 +1,11 @@
 name: Build and Push Docker Image
 
 on:
- push:
+ push: 
+    # Push to main branch triggers the workflow
    branches:
      - main
+ # bila commit, akan ada PR untuk validated before merge
  pull_request:
 
 jobs:
@@ -11,12 +13,13 @@ jobs:
    name: Build and Push Docker Image
    runs-on: ubuntu-latest
     
+    #
    steps:
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
 
      - name: Login to Docker Hub
-       uses: docker/login-action@v3
+       uses: docker/login-action@v4
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
@@ -25,7 +28,7 @@ jobs:
        id: docker_meta
        uses: docker/metadata-action@v5
        with:
-         images: headinthecloudsonline/docker-ci-dockerhub
+         images: miranazli/docker-manual-dockerhub
          flavor: |
            latest=false
          tags: |

--- a/index.html
+++ b/index.html
@@ -29,8 +29,9 @@
 </head>
 <body>
 	<div class="container">
-		<h1>Welcome to headintheclouds</h1>
-		<p>This is a Docker CI/CD pipeline tutorial using GitHub Actions.</p>
+		<h1>SC PROJECT 1</h1>
+		<p>1. Create docker image from github project repo.</p>
+		<p>2. Push to docker hub.</p>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that builds a Docker image and pushes it to Docker Hub automatically when changes are pushed to the main branch or a pull request is opened.

✅ Workflow location: `.github/workflows/docker-image-build.yaml`  
✅ Image is pushed to: `miranazli/docker-manual-dockerhub`  
✅ Tags used: `01`  
✅ SSH key and Docker secrets are configured correctly

Please review and merge to activate CI/CD for Docker builds.
